### PR TITLE
CI: debian: use checkout@v4 instead of v2

### DIFF
--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -19,7 +19,7 @@ jobs:
           sudo -E apt-get --assume-yes dist-upgrade
           sudo -E apt-get --assume-yes install git
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: setup-data
       - name: Set up runner machine
@@ -45,7 +45,7 @@ jobs:
     runs-on: [self-hosted, forrest, debian-bookworm-yocto]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: setup-data
       - name: Install Software
@@ -72,7 +72,7 @@ jobs:
     runs-on: [self-hosted, forrest, debian-bookworm-ptxdist]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: setup-data
       - name: Install Software


### PR DESCRIPTION
This solves complaints about the nodejs version used by the v2 action.