### PR TITLE
CI: debian: remove unattended-upgrades

### DIFF
--- a/base/setup.sh
+++ b/base/setup.sh
@@ -14,7 +14,8 @@ echo "shared-git /srv/shared-git 9p defaults,nofail 0 0" | sudo tee -a /etc/fsta
 
 prepare
 
-sudo -E apt-get --assume-yes purge openssh-server
+sudo systemctl stop unattended-upgrades
+sudo -E apt-get --assume-yes purge openssh-server unattended-upgrades
 sudo -E apt-get --assume-yes install rsync ssh gcc
 
 cleanup


### PR DESCRIPTION
For some reason the `unattended-upgrades` package comes pre-installed on [debian cloud images][1].
This can result in the `apt-get` calls in the jobs contending with `unattended-upgrades` for the dpkg lock.

[1]: https://salsa.debian.org/cloud-team/debian-cloud-images/-/blob/1b9cc10300a5e47c282110e81913a2cbfed3dd00/config_space/bookworm/package_config/SYSTEM_BOOT#L15