### PR TITLE
Implement common git cache via objects/info/alternates

### DIFF
--- a/.github/workflows/debian-trixie.yaml
+++ b/.github/workflows/debian-trixie.yaml
@@ -3,13 +3,13 @@ name: Debian trixie based machines
 on:
   push:
     branches:
-      - main
+      - lgo/git-alternate-object
   workflow_dispatch:
 
 jobs:
   trixie-base:
     name: Base (trixie)
-    runs-on: [self-hosted, forrest, debian-trixie-base]
+    runs-on: [self-hosted, forrest, debian-trixie-gitcache-base]
     steps:
       - name: Install essential packages
         run: |
@@ -35,7 +35,7 @@ jobs:
   trixie-debos:
     name: Debos (trixie)
     needs: trixie-base
-    runs-on: [self-hosted, forrest, debian-trixie-debos]
+    runs-on: [self-hosted, forrest, debian-trixie-gitcache-debos]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
   trixie-yocto:
     name: Yocto (trixie)
     needs: trixie-base
-    runs-on: [self-hosted, forrest, debian-trixie-yocto]
+    runs-on: [self-hosted, forrest, debian-trixie-gitcache-yocto]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
   trixie-ptxdist:
     name: PTXdist (trixie)
     needs: trixie-base
-    runs-on: [self-hosted, forrest, debian-trixie-ptxdist]
+    runs-on: [self-hosted, forrest, debian-trixie-gitcache-ptxdist]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/debian-trixie.yaml
+++ b/.github/workflows/debian-trixie.yaml
@@ -82,3 +82,17 @@ jobs:
       - uses: forrest-runner/persist@main
         with:
           token: ${{ secrets.PERSISTENCE_TOKEN }}
+
+  clone-test:
+    name: Git Clone Test
+    needs: trixie-yocto
+    runs-on: [self-hosted, forrest, debian-trixie-gitcache-yocto]
+    steps:
+      - name: Checkout Poky with cache
+        run: git clone --verbose --progress https://github.com/yoctoproject/poky.git poky-cached
+
+      - name: Disable cache
+        run: sudo rm /etc/gitconfig
+
+      - name: Checkout Poky without cache
+        run: git clone --verbose --progress https://github.com/yoctoproject/poky.git poky-uncached

--- a/base/git-template/objects/info/alternates
+++ b/base/git-template/objects/info/alternates
@@ -1,0 +1,1 @@
+/var/cache/forrest/common.git/objects

--- a/base/gitconfig
+++ b/base/gitconfig
@@ -1,0 +1,2 @@
+[init]
+    templatedir = /etc/git/template

--- a/base/setup.sh
+++ b/base/setup.sh
@@ -15,10 +15,6 @@ sudo sed -i "s/,discard,/,nodiscard,/" /etc/fstab
 mkdir -p ~/.ssh
 cat "$selfdir/known_hosts" >> ~/.ssh/known_hosts
 
-# Git repositories that can be used as reference to speed up clones.
-sudo mkdir -p /srv/shared-git
-echo "shared-git /srv/shared-git 9p defaults,nofail 0 0" | sudo tee -a /etc/fstab
-
 prepare
 
 # The unattended-upgrades service comes pre-installed on the Debian cloud

--- a/base/setup.sh
+++ b/base/setup.sh
@@ -15,6 +15,13 @@ sudo sed -i "s/,discard,/,nodiscard,/" /etc/fstab
 mkdir -p ~/.ssh
 cat "$selfdir/known_hosts" >> ~/.ssh/known_hosts
 
+# Set up a common git repository that objects are searched in before being
+# downloaded from the internet.
+sudo mkdir -p /var/cache/forrest /etc/git
+sudo git init --bare "/var/cache/forrest/common.git"
+sudo cp -R "${selfdir}/git-template" /etc/git/template
+sudo cp "${selfdir}/gitconfig" /etc/gitconfig
+
 prepare
 
 # The unattended-upgrades service comes pre-installed on the Debian cloud

--- a/common/common.sh
+++ b/common/common.sh
@@ -13,3 +13,23 @@ cleanup () {
     sudo -E apt-get --assume-yes clean
     rm -rf setup-data
 }
+
+cache_git_repos () {
+    common_git="/var/cache/forrest/common.git"
+    git="sudo git --git-dir ${common_git}"
+
+    while IFS= read -r url; do
+        name="$(echo "${url}" | grep -oE '[^/]+$' | sed 's/\.git$//')"
+
+        echo "::group::git fetch ${name}"
+        $git fetch \
+          --no-tags \
+          --refetch \
+          --no-auto-maintenance \
+          --no-auto-gc \
+          --write-commit-graph \
+          "${url}" \
+          "+refs/*:refs/cache/${name}/*"
+        echo "::endgroup::"
+    done < "$1"
+}

--- a/yocto/cached-repos
+++ b/yocto/cached-repos
@@ -1,0 +1,11 @@
+https://github.com/labgrid-project/meta-labgrid.git
+https://github.com/openembedded/meta-openembedded.git
+https://github.com/pengutronix/meta-ptx.git
+https://github.com/rauc/meta-rauc.git
+https://git.openembedded.org/bitbake
+https://git.openembedded.org/openembedded-core
+https://git.yoctoproject.org/meta-arm
+https://git.yoctoproject.org/meta-security
+https://git.yoctoproject.org/meta-selinux
+https://git.yoctoproject.org/meta-virtualization
+https://git.yoctoproject.org/poky

--- a/yocto/setup.sh
+++ b/yocto/setup.sh
@@ -14,6 +14,8 @@ cat "$selfdir/ssh_config" >> ~/.ssh/config
 sudo mkdir -p /srv/cache
 echo "cache /srv/cache 9p defaults,nofail 0 0" | sudo tee -a /etc/fstab
 
+cache_git_repos "${selfdir}/cached-repos"
+
 prepare
 
 sudo -E apt-get install --assume-yes --no-install-recommends \


### PR DESCRIPTION
This effectively behaves like setting `--reference ...` for _all_ repositories created on the machine.
The repository being pointed to then contains objects for many different git repositories.

This should speed up cloning of these recipes in the checkout action and build recipes.