### PR TITLE
ci: add trixie-labgrid-client

### DIFF
--- a/.github/workflows/debian-trixie.yaml
+++ b/.github/workflows/debian-trixie.yaml
@@ -82,3 +82,20 @@ jobs:
       - uses: forrest-runner/persist@main
         with:
           token: ${{ secrets.PERSISTENCE_TOKEN }}
+
+  trixie-labgrid-client:
+    name: Labgrid Test Job Runner (trixie)
+    needs: trixie-base
+    runs-on: [self-hosted, forrest, debian-trixie-labgrid-client]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          path: setup-data
+
+      - name: Install Software
+        run: $PWD/setup-data/trixie-labgrid-client/setup.sh
+
+      - uses: forrest-runner/persist@main
+        with:
+          token: ${{ secrets.PERSISTENCE_TOKEN }}

--- a/trixie-labgrid-client/setup.sh
+++ b/trixie-labgrid-client/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -ex
+
+self="$(realpath "${0}")" && selfdir="$(dirname "${self}")"
+
+source "${selfdir}/../common/common.sh"
+
+prepare
+
+sudo -E apt-get install --assume-yes --no-install-recommends \
+    pipx
+
+pipx ensurepath
+pipx install git+https://github.com/labgrid-project/labgrid
+
+cleanup


### PR DESCRIPTION
Add a job for building a Debian trixie image with labgrid installed.

Mostly copied from the debos image. Labgrid is installed with pipx as there is no Debian package for uv.