### PR TITLE
labgrid-client: fix install with pipx, set LG_COORDINATOR

### DIFF
--- a/base/setup.sh
+++ b/base/setup.sh
@@ -13,6 +13,8 @@ source "${selfdir}/../common/common.sh"
 sudo sed -i "s/,discard,/,nodiscard,/" /etc/fstab
 
 mkdir -p ~/.ssh
+curl --proto '=https' --tlsv1.2 -sSf \
+    https://www.pengutronix.de/ssh_known_hosts/all_keys.txt -o ~/.ssh/known_hosts
 cat "$selfdir/known_hosts" >> ~/.ssh/known_hosts
 
 # Git repositories that can be used as reference to speed up clones.

--- a/labgrid-client/setup.sh
+++ b/labgrid-client/setup.sh
@@ -16,4 +16,7 @@ sudo -E apt-get install --assume-yes --no-install-recommends \
 sudo -E pipx install --global --include-deps \
     git+https://github.com/labgrid-project/labgrid
 
+echo 'LG_COORDINATOR="hekla.cuskci.stw.pengutronix.de:20408"' \
+    | sudo tee -a /etc/environment
+
 cleanup

--- a/labgrid-client/setup.sh
+++ b/labgrid-client/setup.sh
@@ -13,7 +13,7 @@ sudo cp "${selfdir}/20-cuskci.network" /etc/systemd/network/
 sudo -E apt-get install --assume-yes --no-install-recommends \
     pipx
 
-pipx ensurepath
-pipx install git+https://github.com/labgrid-project/labgrid
+sudo -E pipx install --global --include-deps \
+    git+https://github.com/labgrid-project/labgrid
 
 cleanup

--- a/labgrid-client/setup.sh
+++ b/labgrid-client/setup.sh
@@ -11,7 +11,9 @@ prepare
 sudo cp "${selfdir}/20-cuskci.network" /etc/systemd/network/
 
 sudo -E apt-get install --assume-yes --no-install-recommends \
-    pipx
+    pipx qemu-system-x86 ovmf swtpm
+
+sudo usermod -aG kvm runner
 
 sudo -E pipx install --global --include-deps \
     git+https://github.com/labgrid-project/labgrid


### PR DESCRIPTION
We cannot use `pipx ensurepath` and amend the bashrc because GitHub Actions are executed in a non-interactive shell where the bashrc is not sourced. Install labgrid globally with pipx so `/usr/local/bin/` is used instead.

Add `--include-deps` so `pytest` is available as well.

Set `LG_COORDINATOR=labgrid` in `/etc/environment`.