### PR TITLE
base: install tpm2-pkcs11 and use it for SSH

### DIFF
--- a/base/setup.sh
+++ b/base/setup.sh
@@ -30,6 +30,6 @@ prepare
 sudo systemctl stop unattended-upgrades
 sudo -E apt-get --assume-yes purge openssh-server unattended-upgrades
 
-sudo -E apt-get --assume-yes install rsync ssh gcc
+sudo -E apt-get --assume-yes install rsync ssh
 
 cleanup

--- a/base/setup.sh
+++ b/base/setup.sh
@@ -30,6 +30,8 @@ prepare
 sudo systemctl stop unattended-upgrades
 sudo -E apt-get --assume-yes purge openssh-server unattended-upgrades
 
-sudo -E apt-get --assume-yes install rsync ssh
+sudo -E apt-get --assume-yes install libtpm2-pkcs11-1 rsync ssh
+
+sudo usermod -aG tss "$(whoami)"
 
 cleanup

--- a/base/ssh_config
+++ b/base/ssh_config
@@ -1,3 +1,7 @@
+# Use tpm2-pkcs11 if a TPM device is present and a store is set up
+Match exec "test -e /dev/tpm0 -a -e ~/.tpm2_pkcs11"
+  PKCS11Provider /usr/lib/x86_64-linux-gnu/pkcs11/libtpm2_pkcs11.so
+
 Host ptxdist-cache
   Hostname 10.0.2.2
   User ptxdist-cache

--- a/labgrid-client/setup.sh
+++ b/labgrid-client/setup.sh
@@ -15,7 +15,7 @@ sudo cp "${selfdir}/20-cuskci.network" /etc/systemd/network/
 sudo -E apt-get install --assume-yes --no-install-recommends \
     pipx qemu-system-x86 ovmf swtpm
 
-sudo usermod -aG kvm runner
+sudo usermod -aG kvm "$(whoami)"
 
 sudo -E pipx install --global --include-deps \
     git+https://github.com/labgrid-project/labgrid


### PR DESCRIPTION
This enables us to log into hosts via SSH without exposing the private key to the running jobs.

This has become possible with the merge of https://github.com/forrest-runner/forrest/pull/49.